### PR TITLE
Switch to OpenJDK, mount LIFERAY_HOME

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,26 @@
-FROM java:8
+FROM openjdk:8-jdk
 
 RUN apt-get update
 
 # Install Ant
-RUN apt-get --assume-yes install ant
+
 ENV ANT_OPTS -Xmx2048m -Xms2048m -XX:MaxPermSize=512m
 
+RUN apt-get --assume-yes install ant
+
 # Install Firefox
-RUN wget https://ftp.mozilla.org/pub/firefox/releases/45.0.1esr/linux-x86_64/en-US/firefox-45.0.1esr.tar.bz2
-RUN tar -xjvf firefox-45.0.1esr.tar.bz2
-RUN mv firefox/ /usr/lib/firefox/
-RUN ln -s /usr/lib/firefox/firefox /usr/bin/firefox
-RUN firefox -version
+
+RUN apt-get --assume-yes install libdbus-glib-1-2 && \
+	wget https://ftp.mozilla.org/pub/firefox/releases/45.0.1esr/linux-x86_64/en-US/firefox-45.0.1esr.tar.bz2 && \
+	tar -xjvf firefox-45.0.1esr.tar.bz2 && \
+	mv firefox/ /usr/lib/firefox/ && \
+	ln -s /usr/lib/firefox/firefox /usr/bin/firefox && \
+	firefox -version
 
 # Setting up headless screen
-RUN apt-get --assume-yes install Xvfb
-RUN apt-get --assume-yes install libxtst6
+
 ENV DISPLAY :99
-RUN (echo "Xvfb :99 -screen 0 1680x1050x16 &> xvfb.log &" ; echo "echo 'Virtual Screen Created'") >> /run.sh
-RUN chmod a+x /run.sh
+
+RUN apt-get --assume-yes install xvfb libxtst6 && \
+	(echo "Xvfb :99 -screen 0 1680x1050x16 &> xvfb.log &" ; echo "echo 'Virtual Screen Created'") >> /run.sh && \
+	chmod a+x /run.sh

--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ Note: Results will be stored in the normal location as the docker container simp
 
 ### Known Issues
 
-* Error message during test execution: `Directory /source/../bundles/logs does not exist.` The test will not be able to see errors in the console.
 * Script does not work on Windows because of limitations in GitBash with mounting folders
 * Script uses expression to get your machine's IP. The expression might need to be tweaked to work on your network configuration
 * build-text.xml does a full modules directory search for poshi toggles. This can have a significant impact on performance when starting up poshi-runner.

--- a/run_test.sh
+++ b/run_test.sh
@@ -15,17 +15,17 @@ if [[ ${OS} == *Darwin* ]]
 then
 	open=open
 	sed="sed -i '' -e"
-	url="$(ifconfig en0 | grep 'inet ' | cut -d: -f2 | awk '{ print $2}')"
+	url="docker.for.mac.localhost"
 elif [[ ${OS} == *Linux* ]]
 then
 	open=xdg-open
 	sed="sed -i -e"
-	url="$(ifconfig en0 | grep 'inet ' | cut -d: -f2 | awk '{ print $2}')"
+	url="$(ifconfig docker0 | grep 'inet ' | cut -d: -f2 | awk '{ print $2}')"
 elif [[ ${OS} == *NT* ]]
 then
 	open=start
 	sed="sed -i -e"
-	url="$(ipconfig | grep IPv4 | cut -d: -f2 | awk '{ print $1}')"
+	url="docker.for.win.localhost"
 else
 	echo "Could not detect OS"
 	exit

--- a/run_test.sh
+++ b/run_test.sh
@@ -8,6 +8,7 @@
 ## Setting the port is optional, defaults to 8080
 
 source_dir="$(pwd)"
+source_dir_mount="-v ${source_dir}:/source"
 
 OS=$(uname)
 
@@ -16,6 +17,7 @@ then
 	open=open
 	sed="sed -i '' -e"
 	url="docker.for.mac.localhost"
+	source_dir_mount="${source_dir_mount}:cached"
 elif [[ ${OS} == *Linux* ]]
 then
 	open=xdg-open
@@ -70,7 +72,7 @@ else
 	echo "test.root.properties created"
 fi
 
-docker run -t --rm -v ${source_dir}:/source:cached vicnate5/functional-test-runner /bin/bash -c \
+docker run -t --rm ${source_dir_mount} vicnate5/functional-test-runner /bin/bash -c \
 "/run.sh; cd /source; ant -f build-test.xml run-selenium-test -Dtest.class=${testname}"
 
 echo

--- a/run_test.sh
+++ b/run_test.sh
@@ -7,6 +7,8 @@
 ##
 ## Setting the port is optional, defaults to 8080
 
+docker_image="vicnate5/functional-test-runner"
+
 source_dir="$(pwd)"
 source_dir_mount="-v ${source_dir}:/source"
 
@@ -92,7 +94,7 @@ else
 	echo "test.root.properties created"
 fi
 
-docker run -t --rm ${source_dir_mount} ${liferay_home_mount} vicnate5/functional-test-runner /bin/bash -c \
+docker run -t --rm ${source_dir_mount} ${liferay_home_mount} ${docker_image} /bin/bash -c \
 "/run.sh; cd /source; ant -f build-test.xml run-selenium-test -Dtest.class=${testname}"
 
 echo


### PR DESCRIPTION
The Java 8 image is deprecated:

https://hub.docker.com/r/library/java

Also, I think the log issue is resolved if you simply mount LIFERAY_HOME, and so I've updated run_test.sh to do so.

I was on WiFi and the script failed to run on Linux, so I've modified the IP detection to use `docker0` on Linux and use `docker.for.mac.localhost` and `docker.for.win.localhost` for OSX and Windows, respectively, which were mentioned in some release notes in the latest Docker.

https://docs.docker.com/docker-for-mac/networking/
https://docs.docker.com/docker-for-windows/release-notes/